### PR TITLE
Add Docker setup for Ruby 3.3 and Rails 8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+bundle
+log
+/tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:3.3
+
+# Install dependencies
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Rails 8.0
+RUN gem install rails -v 8.0.0
+
+COPY Gemfile* /app/
+RUN bundle install || true
+
+COPY . /app
+
+CMD ["bash"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 8.0.0'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # codex_sample
+
+This repository contains a minimal Docker setup for a Ruby on Rails environment.
+
+## Requirements
+- Docker
+- Docker Compose
+
+## Usage
+1. Build the Docker image:
+   ```
+   docker-compose build
+   ```
+2. Run the Rails server (this installs gems on startup):
+   ```
+   docker-compose up
+   ```
+
+If you don't yet have a Rails application, you can create one inside the container:
+
+```
+docker-compose run --rm web rails new . --force --database=sqlite3
+```
+
+Then run `docker-compose up` to start the server on <http://localhost:3000>.
+
+The Dockerfile installs Ruby 3.3 and Rails 8.0.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    command: bash -lc "bundle install && rm -f tmp/pids/server.pid && rails server -b 0.0.0.0"


### PR DESCRIPTION
## Summary
- add a `Dockerfile` that installs Ruby 3.3 and Rails 8.0
- add `docker-compose.yml` to run the Rails server
- track dependencies in a `Gemfile`
- ignore build artifacts with `.dockerignore`
- document how to use the Docker environment in `README.md`
- ensure `docker-compose` installs gems before starting Rails

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e1e755c883248762c5fb6b4ea59b